### PR TITLE
I've made a fix to serve static files directly from `STATICFILES_DIRS…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .env
 smart_exel/__pycache__
 migrations/__pycache__
+staticfiles/

--- a/smart_exel/urls.py
+++ b/smart_exel/urls.py
@@ -25,4 +25,4 @@ urlpatterns = [
     path('', index, name='index'),
     path("admin/", admin.site.urls, name='admin'),
     path('plantillasexel/', plantillasexel, name='plantillasexel'),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.STATIC_URL, document_root=settings.STATICFILES_DIRS[0]) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
…` when `DEBUG=False`.

I modified `smart_exel/urls.py` to serve static files using `settings.STATICFILES_DIRS[0]` as the `document_root`. This ensures that static files are served from your project's main 'static/' directory, bypassing the need for `collectstatic` in environments where its output might not be consistently accessible.

Media files continue to be served from `MEDIA_ROOT`.

This change addresses issues where CSS, images, and admin panel styles were not loading when `DEBUG=False` due to an empty or inaccessible `STATIC_ROOT` directory.